### PR TITLE
revert: read package.json#packageManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ This is where `npx ci` comes in:
 	It's actually the _safer_ option too!
 
 
+## FAQ
+
+### Can it detect the package manager without a lock file?
+
+It's possible to detect the package manager using other signals (eg [`package.json#packageManager`](https://nodejs.org/api/packages.html#packagemanager), `.yarnrc.yml`).
+
+However, since `npx ci` is strictly an alternative to `npm ci`, a lock file is necessary to do a _clean_/_immutable_/_frozen_ install.
+
 ## Related
 
 - [`npx link`](https://github.com/privatenumber/link) - A safer `npm link`.

--- a/src/ci.ts
+++ b/src/ci.ts
@@ -2,58 +2,23 @@ import { existsSync } from 'fs';
 import { spawnSync } from 'child_process';
 import { getPnpmVersion, type Version } from './get-pnpm-version';
 
-function getPackageManager() {
-	try {
-		const { packageManager } = require('./package.json');
-		if (
-			typeof packageManager === 'string'
-			&& packageManager.includes('@')
-		) {
-			return packageManager;
-		}
-	} catch {}
-}
-
 export function ci() {
 	const options = {
 		stdio: 'inherit' as const,
 		shell: true,
 	};
 
-	const packageManager = getPackageManager();
-	if (packageManager) {
-		const [packageManagerName] = packageManager.split('@');
-
-		if (packageManagerName === 'npm') {
-			return spawnSync('npx', [packageManager, 'ci'], options);
-		}
-
-		if (packageManagerName === 'yarn') {
-			/**
-			 * Using the latest yarn will detect the appropriate version to use via .yarnrc.yml
-			 *
-			 * Yarn projects actually check in the yarn binary at .yarn/releases
-			 * https://yarnpkg.com/getting-started/install
-			*/
-			return spawnSync('npx', ['yarn', '--immutable'], options);
-		}
-
-		if (packageManagerName === 'pnpm') {
-			return spawnSync(
-				'npx',
-				[packageManager, 'i', '--frozen-lockfile'],
-				options,
-			);
-		}
-
-		console.warn(`Error: unknown packageManager ${packageManagerName}`);
-	}
-
 	if (existsSync('package-lock.json')) {
 		return spawnSync('npm', ['ci'], options);
 	}
 
 	if (existsSync('yarn.lock')) {
+		/**
+		 * Using the latest yarn will detect the appropriate version to use via .yarnrc.yml
+		 *
+		 * Yarn projects actually check in the yarn binary at .yarn/releases
+		 * https://yarnpkg.com/getting-started/install
+		*/
 		return spawnSync('npx', ['yarn', '--immutable'], options);
 	}
 


### PR DESCRIPTION
@JounQin After thinking about it deeper, I decided to revert the `packageManager` change from `npx ci` because `npm ci`, `pnpm i --frozen-lockfile`, `yarn --immutable` all require a lock file.

That said, it doesn't make sense to read from `packageManager` if the lock file is missing. If it's not missing, it should be enough to use it to detect the package manager.